### PR TITLE
Fix typo on exception message

### DIFF
--- a/GettingStarted.cs
+++ b/GettingStarted.cs
@@ -79,7 +79,7 @@ namespace QueueStorage
             }
             catch 
             {
-                Console.WriteLine("If you are running with the default configuration please make sure you have started the storage emulator.  ess the Windows key and type Azure Storage to select and run it from the list of applications - then restart the sample.");
+                Console.WriteLine("If you are running with the default configuration please make sure you have started the storage emulator. Press the Windows key and type Azure Storage to select and run it from the list of applications - then restart the sample.");
                 Console.ReadLine();
                 throw;
             }


### PR DESCRIPTION
Typo (ess instead of Press) on the error message shown when failing to create a new queue (CreateQueueAsync)